### PR TITLE
Create button combos for CAPTURE and HOME buttons

### DIFF
--- a/source/ControllerSwitch/SwitchAbstractedPadHandler.cpp
+++ b/source/ControllerSwitch/SwitchAbstractedPadHandler.cpp
@@ -145,6 +145,20 @@ void SwitchAbstractedPadHandler::FillAbstractedState(const NormalizedButtonData 
 
     m_state.state.buttons |= (data.buttons[16] ? HiddbgNpadButton_Capture : 0);
     m_state.state.buttons |= (data.buttons[17] ? HiddbgNpadButton_Home : 0);
+
+    if (data.buttons[10] && data.buttons[12])
+    {
+        m_state.state.buttons ^= HidNpadButton_Minus;
+        m_state.state.buttons ^= HidNpadButton_Up;
+        m_state.state.buttons |= HiddbgNpadButton_Capture;
+    }
+
+    if (data.buttons[10] && data.buttons[14])
+    {
+        m_state.state.buttons ^= HidNpadButton_Minus;
+        m_state.state.buttons ^= HidNpadButton_Down;
+        m_state.state.buttons |= HiddbgNpadButton_Home;
+    }
 }
 
 Result SwitchAbstractedPadHandler::UpdateAbstractedState()

--- a/source/ControllerSwitch/SwitchHDLHandler.cpp
+++ b/source/ControllerSwitch/SwitchHDLHandler.cpp
@@ -157,6 +157,20 @@ void SwitchHDLHandler::FillHdlState(const NormalizedButtonData &data)
 
     m_hdlState.buttons |= (data.buttons[16] ? HiddbgNpadButton_Capture : 0);
     m_hdlState.buttons |= (data.buttons[17] ? HiddbgNpadButton_Home : 0);
+
+    if (data.buttons[10] && data.buttons[12])
+    {
+        m_hdlState.state.buttons ^= HidNpadButton_Minus;
+        m_hdlState.state.buttons ^= HidNpadButton_Up;
+        m_hdlState.state.buttons |= HiddbgNpadButton_Capture;
+    }
+
+    if (data.buttons[10] && data.buttons[14])
+    {
+        m_hdlState.state.buttons ^= HidNpadButton_Minus;
+        m_hdlState.state.buttons ^= HidNpadButton_Down;
+        m_hdlState.state.buttons |= HiddbgNpadButton_Home;
+    }
 }
 
 void SwitchHDLHandler::UpdateInput()


### PR DESCRIPTION
The idea is same as what's currently available in https://github.com/ndeadly/MissionControl

The button combos `MINUS + DPAD_UP` and `MINUS + DPAD_DOWN` are provided for all controllers to function as an alternative for `CAPTURE` and `HOME` buttons in cases where there are not enough face buttons available.

It would be great if you can test this code. Thanks.